### PR TITLE
Rename plugin to app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Create Probot Plugin
+# Create Probot App
 
-Create a new [probot](https://github.com/probot/probot) plugin.
+Create a new [Probot](https://github.com/probot/probot) app.
 
 ## Get Started
 
 ```
-npm install -g create-probot-plugin
+npm install -g create-probot-app
 
-create-probot-plugin my-plugin
-cd my-plugin
+create-probot-app my-app
+cd my-app
 ```
 
-See the [probot docs](https://github.com/probot/probot/blob/master/docs/plugins.md) for more information.
+See the [Probot docs](https://probot.github.io/docs/) for more information.

--- a/bin/create-probot-app.js
+++ b/bin/create-probot-app.js
@@ -12,7 +12,7 @@ const spawn = require('cross-spawn');
 const stringifyAuthor = require('stringify-author');
 const {guessEmail, guessAuthor, guessGitHubUsername} = require('conjecture');
 
-const TEMPLATE_REPO_URL = 'https://github.com/probot/plugin-template.git';
+const TEMPLATE_REPO_URL = 'https://github.com/probot/template.git';
 
 program
   .usage('[options] [destination]')

--- a/bin/create-probot-app.js
+++ b/bin/create-probot-app.js
@@ -74,7 +74,7 @@ const prompts = [
   {
     type: 'input',
     name: 'homepage',
-    message: 'App homepage:',
+    message: 'Homepage:',
     when: !program.homepage
   },
   {

--- a/bin/create-probot-app.js
+++ b/bin/create-probot-app.js
@@ -12,7 +12,7 @@ const spawn = require('cross-spawn');
 const stringifyAuthor = require('stringify-author');
 const {guessEmail, guessAuthor, guessGitHubUsername} = require('conjecture');
 
-const TEMPLATE_REPO_URL = 'https://github.com/probot/template.git';
+const TEMPLATE_REPO_URL = 'https://github.com/probot/plugin-template.git';
 
 program
   .usage('[options] [destination]')

--- a/bin/create-probot-app.js
+++ b/bin/create-probot-app.js
@@ -12,22 +12,22 @@ const spawn = require('cross-spawn');
 const stringifyAuthor = require('stringify-author');
 const {guessEmail, guessAuthor, guessGitHubUsername} = require('conjecture');
 
-const PLUGIN_REPO_URL = 'https://github.com/probot/plugin-template.git';
+const TEMPLATE_REPO_URL = 'https://github.com/probot/template.git';
 
 program
   .usage('[options] [destination]')
-  .option('-p, --pkgname <package-name>', 'Plugin package name')
+  .option('-p, --pkgname <package-name>', 'Package name')
   .option('-d, --desc "<description>"',
-    'Plugin description (contain in quotes)')
+    'Description (contain in quotes)')
   .option('-a, --author "<full-name>"',
-    'Plugin author name (contain in quotes)')
-  .option('-e, --email <email>', 'Plugin author email address')
-  .option('-h, --homepage <homepage>', 'Plugin author\'s homepage')
+    'Author name (contain in quotes)')
+  .option('-e, --email <email>', 'Author email address')
+  .option('-h, --homepage <homepage>', 'Author\'s homepage')
   .option('-u, --user <username>', 'GitHub username or org (repo owner)')
-  .option('-r, --repo <repo-name>', 'Plugin repo name')
+  .option('-r, --repo <repo-name>', 'Repository name')
   .option('--overwrite', 'Overwrite existing files', false)
-  .option('--template <template-url>', 'URL of custom plugin template',
-    PLUGIN_REPO_URL)
+  .option('--template <template-url>', 'URL of custom template',
+    TEMPLATE_REPO_URL)
   .parse(process.argv);
 
 const destination = program.args.length ?
@@ -41,16 +41,16 @@ const prompts = [
     default(answers) {
       return answers.repo || kebabCase(path.basename(destination));
     },
-    message: 'Plugin\'s package name:',
+    message: 'Package name:',
     when: !program.pkgname
   },
   {
     type: 'input',
     name: 'desc',
     default() {
-      return 'A Probot plugin';
+      return 'A Probot app';
     },
-    message: 'Description of plugin:',
+    message: 'Description of app:',
     when: !program.desc
   },
   {
@@ -59,7 +59,7 @@ const prompts = [
     default() {
       return guessAuthor();
     },
-    message: 'Plugin author\'s full name:',
+    message: 'Author\'s full name:',
     when: !program.author
   },
   {
@@ -68,13 +68,13 @@ const prompts = [
     default() {
       return guessEmail();
     },
-    message: 'Plugin author\'s email address:',
+    message: 'Author\'s email address:',
     when: !program.email
   },
   {
     type: 'input',
     name: 'homepage',
-    message: 'Plugin author\'s homepage:',
+    message: 'App homepage:',
     when: !program.homepage
   },
   {
@@ -83,7 +83,7 @@ const prompts = [
     default(answers) {
       return guessGitHubUsername(answers.email);
     },
-    message: 'Plugin\'s GitHub user or org name:',
+    message: 'GitHub user or org name:',
     when: !program.user
   },
   {
@@ -92,12 +92,12 @@ const prompts = [
     default(answers) {
       return answers.pkgname || kebabCase(path.basename(destination));
     },
-    message: 'Plugin\'s repo name:',
+    message: 'Repository name:',
     when: !program.repo
   }
 ];
 
-console.log(chalk.blue('Let\'s create a Probot plugin!'));
+console.log(chalk.blue('Let\'s create a Probot app!'));
 
 inquirer.prompt(prompts)
   .then(answers => {
@@ -125,6 +125,6 @@ inquirer.prompt(prompts)
         console.log(chalk.red(`Could not install npm dependencies. Try running ${chalk.bold('npm install')} yourself.`));
         return;
       }
-      console.log(chalk.blue('\nDone! Enjoy building your Probot plugin!'));
+      console.log(chalk.blue('\nDone! Enjoy building your Probot app!'));
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "create-probot-plugin",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "create-probot-plugin",
+  "name": "create-probot-app",
   "version": "1.0.1",
-  "description": "Create a probot plugin",
+  "description": "Create a Probot app",
   "bin": {
-    "create-probot-plugin": "./bin/create-probot-plugin.js"
+    "create-probot-app": "./bin/create-probot-app.js"
   },
   "scripts": {
     "test": "xo --extend probot"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/probot/create-probot-plugin.git"
+    "url": "git+https://github.com/probot/create-probot-app.git"
   },
   "keywords": [
     "probot"
@@ -18,9 +18,9 @@
   "author": "Brandon Keepers",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/probot/create-probot-plugin/issues"
+    "url": "https://github.com/probot/create-probot-app/issues"
   },
-  "homepage": "https://github.com/probot/create-probot-plugin#readme",
+  "homepage": "https://github.com/probot/create-probot-app#readme",
   "dependencies": {
     "chalk": "^2.0.1",
     "commander": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-probot-app",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Create a Probot app",
   "bin": {
     "create-probot-app": "./bin/create-probot-app.js"


### PR DESCRIPTION
- [x] Release `create-probot-app`
- [x] Test that `create-probot-app` works
- [x] Update https://github.com/probot/plugin-template (https://github.com/probot/plugin-template/pull/22)
- [x] Merge https://github.com/probot/probot/pull/210
- [x] Rename this repo to create-probot-app
- [x] Deprecate `create-probot-plugin`
