### PR TITLE
Add validation for appname to be a well formed npm package name

### DIFF
--- a/bin/create-probot-app.js
+++ b/bin/create-probot-app.js
@@ -11,6 +11,7 @@ const chalk = require('chalk')
 const spawn = require('cross-spawn')
 const stringifyAuthor = require('stringify-author')
 const {guessEmail, guessAuthor, guessGitHubUsername} = require('conjecture')
+const validatePackageName = require('validate-npm-package-name')
 
 const TEMPLATE_REPO_URL = 'https://github.com/probot/template.git'
 
@@ -42,7 +43,15 @@ const prompts = [
       return answers.repo || kebabCase(path.basename(destination))
     },
     message: 'App name:',
-    when: !program.appName
+    when: !program.appName,
+    validate (appName) {
+      const result = validatePackageName(appName);
+      if(result.errors && result.errors.length > 0) {
+        return result.errors.join(",");
+      }
+
+      return true;
+    }
   },
   {
     type: 'input',

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "egad": "^0.2.0",
     "inquirer": "^3.2.1",
     "lodash.kebabcase": "^4.1.1",
-    "stringify-author": "^0.1.3"
+    "stringify-author": "^0.1.3",
+    "validate-npm-package-name": "^3.0.0"
   },
   "devDependencies": {
     "standard": "^10.0.3"


### PR DESCRIPTION
## What was happening ?
If the user types in an invalid **package name** when the **create-probot-app** asks for an app name then the app throws an error of invalid package name while executing **npm start**.
## My fix
To avoid this I have added the validation of app name while asking using the package [validate-npm-package-name](https://www.npmjs.com/package/validate-npm-package-name)

