### PR TITLE
add invocations to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # Create Probot App
 
-Create a new [Probot](https://github.com/probot/probot) app.
+This project will generate a new [Probot](https://github.com/probot/probot) app 
+with everything you need to get started and run your app in production.
+
+If you're using npm: 
+
+```sh
+npx create-probot-app my-first-app
+```
+
+If you're using Yarn: 
+
+```sh
+yarn create probot-app my-first-app
+```
 
 See the [Probot docs](https://probot.github.io/docs/development/) to get started.


### PR DESCRIPTION
This adds `npx` and `yarn` commands to the README, but still points to the docs for getting started.