### PR TITLE
Add option for scaffolding with a typescript template

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,29 +3,24 @@
 This project will generate a new [Probot](https://github.com/probot/probot) app 
 with everything you need to get started and run your app in production.
 
-If you're using npm: 
+> use the --typescript flag to generate a new TypeScript project
+
+If you're using npm < 6: 
 
 ```sh
-npx create-probot-app my-first-app
+npx create-probot-app [--typescript] my-first-app
+```
+
+If you're using npm > 6: 
+
+```sh
+npm init probot-app [--typescript] my-first-app
 ```
 
 If you're using Yarn: 
 
 ```sh
-yarn create probot-app my-first-app
+yarn create probot-app [--typescript] my-first-app
 ```
-
-Or add `--typescript` to generate a new TypeScript project:
-
-NPM:
-```sh
-npx create-probot-app --typescript my-first-app
-```
-Yarn:
-
-```sh
-yarn create probot-app --typescript my-first-app
-```
-
 
 See the [Probot docs](https://probot.github.io/docs/development/) to get started.

--- a/README.md
+++ b/README.md
@@ -15,4 +15,17 @@ If you're using Yarn:
 yarn create probot-app my-first-app
 ```
 
+Or add `--typescript` to generate a new TypeScript project:
+
+NPM:
+```sh
+npx create-probot-app --typescript my-first-app
+```
+Yarn:
+
+```sh
+yarn create probot-app --typescript my-first-app
+```
+
+
 See the [Probot docs](https://probot.github.io/docs/development/) to get started.

--- a/bin/create-probot-app.js
+++ b/bin/create-probot-app.js
@@ -29,6 +29,7 @@ program
   .option('--overwrite', 'Overwrite existing files', false)
   .option('--template <template-url>', 'URL of custom template',
     TEMPLATE_REPO_URL)
+  .option('--typescript', 'Use the TypeScript template', 'https://github.com/probot/ts-template.git')
   .parse(process.argv)
 
 const destination = program.args.length
@@ -116,6 +117,13 @@ inquirer.prompt(prompts)
       url: answers.homepage
     })
     answers.year = new Date().getFullYear()
+    
+    if (program.typescript) {
+      return scaffold(program.typescript, destination, answers, {
+        overwrite: Boolean(program.overwrite)
+      })  
+    }
+    
     return scaffold(program.template, destination, answers, {
       overwrite: Boolean(program.overwrite)
     })


### PR DESCRIPTION
Fixes #27 and #26 

This adds an option for scaffolding new apps with a TypeScript template (repo to be created). There's a better way to write this that I'm not seeing at the moment, but it works.