### PR TITLE
Add camel-cased app name

### DIFF
--- a/bin/create-probot-app.js
+++ b/bin/create-probot-app.js
@@ -125,7 +125,7 @@ inquirer.prompt(prompts)
       url: answers.homepage
     })
     answers.year = new Date().getFullYear()
-    answers.variable = camelCase(answers.appName)
+    answers.camelCaseAppName = camelCase(answers.appName)
 
     return scaffold(program.template, destination, answers, {
       overwrite: Boolean(program.overwrite)

--- a/bin/create-probot-app.js
+++ b/bin/create-probot-app.js
@@ -7,6 +7,7 @@ const inquirer = require('inquirer')
 const program = require('commander')
 const {scaffold} = require('egad')
 const kebabCase = require('lodash.kebabcase')
+const camelCase = require('lodash.camelcase')
 const chalk = require('chalk')
 const spawn = require('cross-spawn')
 const stringifyAuthor = require('stringify-author')
@@ -124,6 +125,7 @@ inquirer.prompt(prompts)
       url: answers.homepage
     })
     answers.year = new Date().getFullYear()
+    answers.variable = camelCase(answers.appName)
 
     return scaffold(program.template, destination, answers, {
       overwrite: Boolean(program.overwrite)

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "conjecture": "^0.1.2",
     "egad": "^0.2.0",
     "inquirer": "^3.2.1",
+    "lodash.camelcase": "^4.3.0",
     "lodash.kebabcase": "^4.1.1",
     "stringify-author": "^0.1.3",
     "validate-npm-package-name": "^3.0.0"


### PR DESCRIPTION
This PR adds a camel-cased version of the app's title to the scaffolding variables, so that we can use it when, for example, [creating a test](https://github.com/probot/template/pull/74).

I'm not a huge fan of the naming for `answers.variable`, but since it went along with the discussion in that PR I figured it was good enough to show what I was thinking. Open to opinions on better naming 👍 