### PR TITLE
Add option to scaffold from a specific branch of a repository

### DIFF
--- a/bin/create-probot-app.js
+++ b/bin/create-probot-app.js
@@ -54,12 +54,12 @@ const prompts = [
     message: 'App name:',
     when: !program.appName,
     validate (appName) {
-      const result = validatePackageName(appName);
-      if(result.errors && result.errors.length > 0) {
-        return result.errors.join(",");
+      const result = validatePackageName(appName)
+      if (result.errors && result.errors.length > 0) {
+        return result.errors.join(',')
       }
 
-      return true;
+      return true
     }
   },
   {

--- a/bin/create-probot-app.js
+++ b/bin/create-probot-app.js
@@ -26,7 +26,7 @@ program
   .option('-h, --homepage <homepage>', 'Author\'s homepage')
   .option('-u, --user <username>', 'GitHub username or org (repo owner)')
   .option('-r, --repo <repo-name>', 'Repository name')
-  .option('-b, --branch <branch-name>', 'Specify a branch (defaults to `master`)', 'master')
+  .option('-b, --branch <branch-name>', 'Specify a branch', 'master')
   .option('--overwrite', 'Overwrite existing files', false)
   .option('--template <template-url>', 'URL or name of custom template', getTemplateRepository, DEFAULT_TEMPLATE)
   .option('--typescript', 'Use the TypeScript template', () => program.emit('option:template', 'typescript'))

--- a/bin/create-probot-app.js
+++ b/bin/create-probot-app.js
@@ -26,6 +26,7 @@ program
   .option('-h, --homepage <homepage>', 'Author\'s homepage')
   .option('-u, --user <username>', 'GitHub username or org (repo owner)')
   .option('-r, --repo <repo-name>', 'Repository name')
+  .option('-b, --branch <branch-name>', 'Specify a branch (defaults to `master`)')
   .option('--overwrite', 'Overwrite existing files', false)
   .option('--template <template-url>', 'URL or name of custom template', getTemplateRepository, DEFAULT_TEMPLATE)
   .option('--typescript', 'Use the TypeScript template', () => program.emit('option:template', 'typescript'))
@@ -126,7 +127,8 @@ inquirer.prompt(prompts)
     answers.year = new Date().getFullYear()
 
     return scaffold(program.template, destination, answers, {
-      overwrite: Boolean(program.overwrite)
+      overwrite: Boolean(program.overwrite),
+      branch: program.branch
     })
   })
   .then(results => {

--- a/bin/create-probot-app.js
+++ b/bin/create-probot-app.js
@@ -26,7 +26,7 @@ program
   .option('-h, --homepage <homepage>', 'Author\'s homepage')
   .option('-u, --user <username>', 'GitHub username or org (repo owner)')
   .option('-r, --repo <repo-name>', 'Repository name')
-  .option('-b, --branch <branch-name>', 'Specify a branch (defaults to `master`)')
+  .option('-b, --branch <branch-name>', 'Specify a branch (defaults to `master`)', 'master')
   .option('--overwrite', 'Overwrite existing files', false)
   .option('--template <template-url>', 'URL or name of custom template', getTemplateRepository, DEFAULT_TEMPLATE)
   .option('--typescript', 'Use the TypeScript template', () => program.emit('option:template', 'typescript'))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-probot-app",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Create a Probot app",
   "bin": {
     "create-probot-app": "./bin/create-probot-app.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-probot-app",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Create a Probot app",
   "bin": {
     "create-probot-app": "./bin/create-probot-app.js"


### PR DESCRIPTION
To help with testing out changes to various templates (e.g.: https://github.com/probot/template/pull/77/), I thought we should add an option to specify a branch. Turns out [scaffold supports specifying a branch name](https://github.com/boneskull/egad#basic-usage) that defaults to master, so this PR adds a command line flag to allow users to provide this option.

```sh
# Output of help message
➜   npx probot-app --help
Options:
...
-b, --branch <branch-name>  Specify a branch (default: master)
```