### PR TITLE
stringify description

### DIFF
--- a/bin/create-probot-app.js
+++ b/bin/create-probot-app.js
@@ -120,6 +120,7 @@ console.log(chalk.blue('Let\'s create a Probot app!'))
 
 inquirer.prompt(prompts)
   .then(answers => {
+    answers.description = JSON.stringify(answers.description).slice(1,-1)
     answers.author = stringifyAuthor({
       name: answers.author,
       email: answers.email,


### PR DESCRIPTION
## What
- [x] Escape quotes from `answers.description` before passing it to egad's scaffold function.

## Why
Currently [`description` isn't escaped in the probot template](https://github.com/probot/template/blob/a276a49f23696bba017eeac21c30732be6c49c17/package.json#L4) to allow for symbols in the description (`<`, `>` or `&`). This has the adverse effect that if double quotes are used in the description we end up with an invalid JSON file in package.json as they aren't escaped.

For example:
```json
{
  "description: "a description with "quotes"."
}
```

Since it seems we purposely chose to not HTML escape descriptions I'm stringifiying the description and removing the beginning and end quotes of the JSON stringification in order to end up with a valid JSON object. 

Happy to talk about other way of tackling this issue!


## Misc
Closes probot/probot#727