### PR TITLE
Add repo metadata to default template

### DIFF
--- a/templates/basic-js/app.yml
+++ b/templates/basic-js/app.yml
@@ -74,7 +74,7 @@ default_permissions:
 
   # Search repositories, list collaborators, and access repository metadata.
   # https://developer.github.com/v3/apps/permissions/#metadata-permissions
-  # metadata: read
+  metadata: read
 
   # Retrieve Pages statuses, configuration, and builds, as well as create new builds.
   # https://developer.github.com/v3/apps/permissions/#permission-on-pages


### PR DESCRIPTION
I ran into a bug on the first time setup where even though the bot was working, I was getting a 500 error logged to the console:

```shell
{ HttpError
    at response.text.then.message (/Users/tcbyrd/workspaces/probot-tests/basic/node_modules/@octokit/rest/lib/request/request.js:72:19)
    at process.internalTickCallback (internal/process/next_tick.js:77:7)
  name: 'HttpError',
  code: 500,
  status: 'Internal Server Error'
```

Looking up the error internally, it was caused by an abilities mismatch:
```
The GraphQL query has failed and no results were returned.
The records attempting to be returned failed an ability check and are
not accessible to the current viewer (tcbyrd-probot-basic-js):

* "Repository (GraphQL Type: Repository, Global ID: `<redacted>`)"
```

Turning on the repository metadata permission in my app fixed this. Since this a [read only permission that doesn't leak private information](https://developer.github.com/v3/apps/permissions/#metadata-permissions), we should probably be enabling this for any app by default. Importantly, when you go to https://github.com/settings/apps/new, it defaults this to read-only and you have to explicitly disable it, so this change will make the template reflect that default.