### PR TITLE
Make sure to call `done()` in a async test

### DIFF
--- a/templates/basic-ts/test/index.test.ts
+++ b/templates/basic-ts/test/index.test.ts
@@ -23,7 +23,7 @@ describe('My Probot app', () => {
     app.app = () => 'test'
   })
 
-  test('creates a comment when an issue is opened', async () => {
+  test('creates a comment when an issue is opened', async (done) => {
     // Test that we correctly return a test token
     nock('https://api.github.com')
       .post('/app/installations/2/access_tokens')
@@ -32,7 +32,7 @@ describe('My Probot app', () => {
     // Test that a comment is posted
     nock('https://api.github.com')
       .post('/repos/hiimbex/testing-things/issues/1/comments', (body: any) => {
-        expect(body).toMatchObject(issueCreatedBody)
+        done(expect(body).toMatchObject(issueCreatedBody))
         return true
       })
       .reply(200)


### PR DESCRIPTION
Since done isn't called in the example test we never reach the callback where we do the expect assertion causing the tests to pass even when they shouldn't since the test suite doesn't know that we need to wait for the callback to called.

By taking the `done` callback in as argument in the test function we signal to the test suite that this test should fail is `done()` isn't called.

See https://jestjs.io/docs/en/asynchronous.html for further reading.