### PR TITLE
Add started at

### DIFF
--- a/templates/checks-js/index.js
+++ b/templates/checks-js/index.js
@@ -4,6 +4,7 @@ module.exports = app => {
   app.on(['check_suite.requested', 'check_run.rerequested'], check)
 
   async function check (context) {
+    const startTime = new Date()
     // Do stuff
     const { head_branch, head_sha } = context.payload.check_suite
     // Probot API note: context.repo() => {username: 'hiimbex', repo: 'testing-things'}
@@ -12,6 +13,7 @@ module.exports = app => {
       head_branch,
       head_sha,
       status: 'completed',
+      started_at: startTime,
       conclusion: 'success',
       completed_at: new Date(),
       output: {

--- a/templates/checks-js/test/fixtures/check_run.created.json
+++ b/templates/checks-js/test/fixtures/check_run.created.json
@@ -3,6 +3,7 @@
   "head_branch": "hiimbex-patch-46",
   "head_sha": "50e5628cda538bcbb6f3fec3edebe4bb5afb3891",
   "status": "completed",
+  "started_at": "2018-10-05T17:35:21.594Z",
   "conclusion": "success",
   "completed_at": "2018-10-05T17:35:53.683Z",
   "output": {

--- a/templates/checks-js/test/index.test.js
+++ b/templates/checks-js/test/index.test.js
@@ -27,6 +27,7 @@ describe('My Probot app', () => {
 
     nock('https://api.github.com')
       .post('/repos/hiimbex/testing-things/check-runs', (body) => {
+        body.started_at = '2018-10-05T17:35:21.594Z'
         body.completed_at = '2018-10-05T17:35:53.683Z'
         expect(body).toMatchObject(checkRunSuccess)
         return true


### PR DESCRIPTION
This prevents GitHub from reporting:
`{app-name} Successful in -1m`

See https://github.com/probot/probot/issues/803