### PR TITLE
Initialize a Git repository

### DIFF
--- a/bin/create-probot-app.js
+++ b/bin/create-probot-app.js
@@ -14,6 +14,7 @@ const spawn = require('cross-spawn')
 const stringifyAuthor = require('stringify-author')
 const {guessEmail, guessAuthor, guessGitHubUsername} = require('conjecture')
 const validatePackageName = require('validate-npm-package-name')
+const which = require('which')
 
 program
   .usage('[options] [destination]')
@@ -161,8 +162,11 @@ inquirer.prompt(prompts)
       }
     })
   }).then(() => {
-    console.log(chalk.blue('\nInitializing a Git repository!'))
+    if (which.sync('git', { nothrow: true }) === null) {
+      return
+    }
 
+    console.log(chalk.blue('\nInitializing a Git repository!'))
     try {
       require('simple-git')(destination)
         .init()

--- a/bin/create-probot-app.js
+++ b/bin/create-probot-app.js
@@ -179,4 +179,3 @@ inquirer.prompt(prompts)
   }).then(() => {
     console.log(chalk.blue('\nDone! Enjoy building your Probot app!'))
   })
-  

--- a/bin/create-probot-app.js
+++ b/bin/create-probot-app.js
@@ -2,6 +2,7 @@
 
 'use strict'
 
+const fs = require('fs-extra')
 const path = require('path')
 const inquirer = require('inquirer')
 const program = require('commander')
@@ -158,6 +159,20 @@ inquirer.prompt(prompts)
         console.log(chalk.red(`Could not install npm dependencies. Try running ${chalk.bold('npm install')} yourself.`))
         return
       }
-      console.log(chalk.blue('\nDone! Enjoy building your Probot app!'))
     })
+  }).then(() => {
+    console.log(chalk.blue('\nInitializing a Git repository!'))
+
+    try {
+      require('simple-git')(destination)
+        .init()
+        .add('./*')
+        .commit("Initial commit from Create Probot App")
+    } catch (e) {
+      console.log(chalk.red('\nUnable to initialize a Git repository.'))
+      fs.removeSync(path.join(destination, '.git'))
+    }
+  }).then(() => {
+    console.log(chalk.blue('\nDone! Enjoy building your Probot app!'))
   })
+  

--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
     "commander": "^2.11.0",
     "conjecture": "^0.1.2",
     "egad": "^0.2.0",
+    "fs-extra": "^8.1.0",
     "inquirer": "^6.2.2",
     "lodash.camelcase": "^4.3.0",
     "lodash.kebabcase": "^4.1.1",
+    "simple-git": "^1.126.0",
     "stringify-author": "^0.1.3",
     "validate-npm-package-name": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "lodash.kebabcase": "^4.1.1",
     "simple-git": "^1.126.0",
     "stringify-author": "^0.1.3",
-    "validate-npm-package-name": "^3.0.0"
+    "validate-npm-package-name": "^3.0.0",
+    "which": "^2.0.1"
   },
   "devDependencies": {
     "standard": "^12.0.1"


### PR DESCRIPTION
Adds support for initializing a git repo. 

**Side Affects**

Node modules will continue installing in the background even after the last `then` block has been executed - because the process was spawned asynchronously.

Solution: Spawn a process synchronously to install node modules.

#80 is blocking changes to modify that `npm install` line. 

Once #80 is merged I'll add a PR to spawn `npm install` synchronously.