### PR TITLE
fix: remove prepended `./node_modules/.bin` from $PATH

### DIFF
--- a/script/test
+++ b/script/test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$IGNORE_CI_CHECK" != "1" ]; then
   # Detects common CI environments and warn against running in cloud environments.

--- a/script/test
+++ b/script/test
@@ -20,6 +20,8 @@ set -u
 # Print the executed command
 set -x
 
+PATH=$(echo "$PATH" | sed 's/.\/node_modules\/.bin://')
+
 # Ensure we're always running from the project root
 cd "$(dirname "$0")/.."
 

--- a/script/test
+++ b/script/test
@@ -23,7 +23,7 @@ set -x
 # Ensure we're always running from the project root
 cd "$(dirname "$0")/.."
 
-npm install
+npm ci
 npm run build
 
 PROJECT_DIR=$(pwd)


### PR DESCRIPTION
This was fun to track down. Travis is [prepending](https://github.com/travis-ci/travis-build/blob/4a8f957ecddf3ee5b3ba94e1e525c95fb064a98f/lib/travis/build/script/node_js.rb#L26) a relative path - `./node_modules/.bin` - to $PATH.

Running binaries/commands when outside project root would lead to bad path references.

Because semantic-release installs NPM, the NPM binary is always referenced from the root of the project (note: the project root is where the CI shell is instantiated). But once we enter any other directory, that relative reference is bad.

fixes #91