### PR TITLE
chore: Add @MaximDevoir as CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @JasonEtco @tcbyrd
+* @JasonEtco @tcbyrd @MaximDevoir


### PR DESCRIPTION
I have been unable to merge PRs - even with maintainer privileges for this repo. I can't see the branch protection settings, but with the presence of a CODEOWNERs file, I'm guessing the option requiring PRs to be reviewed by a  [CODEOWNER](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) is enabled.

![https://help.github.com/en/github/administering-a-repository/enabling-required-reviews-for-pull-requests](https://help.github.com/assets/images/help/repository/PR-review-required-code-owner.png)
