### PR TITLE
chore: Update minimum node version

### DIFF
--- a/templates/basic-js/package.json
+++ b/templates/basic-js/package.json
@@ -31,7 +31,7 @@
     "standard": "^14.3.4"
   },
   "engines": {
-    "node": ">= 8.3.0"
+    "node": ">= 10.13.0"
   },
   "standard": {
     "env": [

--- a/templates/basic-ts/package.json
+++ b/templates/basic-ts/package.json
@@ -40,7 +40,7 @@
     "typescript": "^3.9.7"
   },
   "engines": {
-    "node": ">= 8.3.0"
+    "node": ">= 10.13.0"
   },
   "standard": {
     "parser": "@typescript-eslint/parser",

--- a/templates/checks-js/package.json
+++ b/templates/checks-js/package.json
@@ -31,7 +31,7 @@
     "standard": "^14.3.4"
   },
   "engines": {
-    "node": ">= 8.3.0"
+    "node": ">= 10.13.0"
   },
   "standard": {
     "env": [

--- a/templates/deploy-js/package.json
+++ b/templates/deploy-js/package.json
@@ -31,7 +31,7 @@
     "standard": "^14.3.4"
   },
   "engines": {
-    "node": ">= 8.3.0"
+    "node": ">= 10.13.0"
   },
   "standard": {
     "env": [

--- a/templates/git-data-js/package.json
+++ b/templates/git-data-js/package.json
@@ -31,7 +31,7 @@
     "standard": "^14.3.4"
   },
   "engines": {
-    "node": ">= 8.3.0"
+    "node": ">= 10.13.0"
   },
   "standard": {
     "env": [


### PR DESCRIPTION
I saw engines in package.json that is used a deprecated version of node
So I feel like that there should be updated to a maintenance version