### PR TITLE
fix: remove standard and nodemon from app templates

### DIFF
--- a/templates/basic-js/CONTRIBUTING.md
+++ b/templates/basic-js/CONTRIBUTING.md
@@ -2,7 +2,6 @@
 
 [fork]: /fork
 [pr]: /compare
-[style]: https://standardjs.com/
 [code-of-conduct]: CODE_OF_CONDUCT.md
 
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
@@ -27,7 +26,6 @@ We'd also love PRs. If you're thinking of a large PR, we advise opening up an is
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:
 
-- Follow the [style guide][style] which is using standard. Any linting errors should be shown when running `npm test`.
 - Write and update tests.
 - Keep your changes as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
 - Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).

--- a/templates/basic-js/package.json
+++ b/templates/basic-js/package.json
@@ -14,11 +14,8 @@
     "probot-app"
   ],
   "scripts": {
-    "dev": "nodemon",
     "start": "probot run ./index.js",
-    "lint": "standard --fix",
-    "test": "jest && standard",
-    "test:watch": "jest --watch --notify --notifyMode=change --coverage"
+    "test": "jest"
   },
   "dependencies": {
     "probot": "^9.13.0"
@@ -26,26 +23,9 @@
   "devDependencies": {
     "jest": "^26.4.0",
     "nock": "^13.0.4",
-    "nodemon": "^2.0.4",
-    "smee-client": "^1.1.0",
-    "standard": "^14.3.4"
+    "smee-client": "^1.1.0"
   },
   "engines": {
     "node": ">= 10.13.0"
-  },
-  "standard": {
-    "env": [
-      "jest"
-    ]
-  },
-  "nodemonConfig": {
-    "exec": "npm start",
-    "watch": [
-      ".env",
-      "."
-    ]
-  },
-  "jest": {
-    "testEnvironment": "node"
   }
 }

--- a/templates/basic-ts/CONTRIBUTING.md
+++ b/templates/basic-ts/CONTRIBUTING.md
@@ -2,7 +2,6 @@
 
 [fork]: /fork
 [pr]: /compare
-[style]: https://standardjs.com/
 [code-of-conduct]: CODE_OF_CONDUCT.md
 
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
@@ -27,7 +26,6 @@ We'd also love PRs. If you're thinking of a large PR, we advise opening up an is
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:
 
-- Follow the [style guide][style] which is using standard. Any linting errors should be shown when running `npm test`.
 - Write and update tests.
 - Keep your changes as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
 - Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).

--- a/templates/basic-ts/README.md
+++ b/templates/basic-ts/README.md
@@ -8,11 +8,10 @@
 # Install dependencies
 npm install
 
-# Run with hot reload
-npm run build:watch
-
-# Compile and run
+# Compile
 npm run build
+
+# Run
 npm run start
 ```
 

--- a/templates/basic-ts/nodemon.json
+++ b/templates/basic-ts/nodemon.json
@@ -1,7 +1,0 @@
-{
-  "signal": "SIGINT",
-  "watch": ["lib", ".env"],
-  "delay": "2000",
-  "verbose": false,
-  "exec": ["npm run start"]
-}

--- a/templates/basic-ts/package.json
+++ b/templates/basic-ts/package.json
@@ -15,12 +15,8 @@
   ],
   "scripts": {
     "build": "tsc",
-    "build:watch": "tsc && (tsc -w --preserveWatchOutput & nodemon)",
-    "dev": "npm run build:watch",
     "start": "probot run ./lib/index.js",
-    "lint": "standard **/*.ts --fix",
-    "test": "jest && standard **/*.ts",
-    "test:watch": "jest --watch --notify --notifyMode=change --coverage"
+    "test": "jest"
   },
   "dependencies": {
     "probot": "^9.13.0"
@@ -33,23 +29,12 @@
     "eslint-plugin-typescript": "^0.14.0",
     "jest": "^26.4.0",
     "nock": "^13.0.4",
-    "nodemon": "^2.0.4",
     "smee-client": "^1.1.0",
-    "standard": "^14.3.4",
     "ts-jest": "^26.2.0",
     "typescript": "^3.9.7"
   },
   "engines": {
     "node": ">= 10.13.0"
-  },
-  "standard": {
-    "parser": "@typescript-eslint/parser",
-    "env": [
-      "jest"
-    ],
-    "plugins": [
-      "typescript"
-    ]
   },
   "jest": {
     "testEnvironment": "node"

--- a/templates/checks-js/CONTRIBUTING.md
+++ b/templates/checks-js/CONTRIBUTING.md
@@ -2,7 +2,6 @@
 
 [fork]: /fork
 [pr]: /compare
-[style]: https://standardjs.com/
 [code-of-conduct]: CODE_OF_CONDUCT.md
 
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
@@ -27,7 +26,6 @@ We'd also love PRs. If you're thinking of a large PR, we advise opening up an is
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:
 
-- Follow the [style guide][style] which is using standard. Any linting errors should be shown when running `npm test`.
 - Write and update tests.
 - Keep your changes as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
 - Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).

--- a/templates/checks-js/package-lock.json
+++ b/templates/checks-js/package-lock.json
@@ -1,5 +1,0 @@
-{
-  "name": "{{ appName }}",
-  "version": "1.0.0",
-  "lockfileVersion": 1
-}

--- a/templates/checks-js/package.json
+++ b/templates/checks-js/package.json
@@ -14,11 +14,8 @@
     "probot-app"
   ],
   "scripts": {
-    "dev": "nodemon",
     "start": "probot run ./index.js",
-    "lint": "standard --fix",
-    "test": "jest && standard",
-    "test:watch": "jest --watch --notify --notifyMode=change --coverage"
+    "test": "jest"
   },
   "dependencies": {
     "probot": "^9.13.0"
@@ -26,24 +23,10 @@
   "devDependencies": {
     "jest": "^26.4.0",
     "nock": "^13.0.4",
-    "nodemon": "^2.0.4",
-    "smee-client": "^1.1.0",
-    "standard": "^14.3.4"
+    "smee-client": "^1.1.0"
   },
   "engines": {
     "node": ">= 10.13.0"
-  },
-  "standard": {
-    "env": [
-      "jest"
-    ]
-  },
-  "nodemonConfig": {
-    "exec": "npm start",
-    "watch": [
-      ".env",
-      "."
-    ]
   },
   "jest": {
     "testEnvironment": "node"

--- a/templates/deploy-js/CONTRIBUTING.md
+++ b/templates/deploy-js/CONTRIBUTING.md
@@ -2,7 +2,6 @@
 
 [fork]: /fork
 [pr]: /compare
-[style]: https://standardjs.com/
 [code-of-conduct]: CODE_OF_CONDUCT.md
 
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
@@ -27,7 +26,6 @@ We'd also love PRs. If you're thinking of a large PR, we advise opening up an is
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:
 
-- Follow the [style guide][style] which is using standard. Any linting errors should be shown when running `npm test`.
 - Write and update tests.
 - Keep your changes as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
 - Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).

--- a/templates/deploy-js/package-lock.json
+++ b/templates/deploy-js/package-lock.json
@@ -1,5 +1,0 @@
-{
-  "name": "{{ appName }}",
-  "version": "1.0.0",
-  "lockfileVersion": 1
-}

--- a/templates/deploy-js/package.json
+++ b/templates/deploy-js/package.json
@@ -14,11 +14,8 @@
     "probot-app"
   ],
   "scripts": {
-    "dev": "nodemon",
     "start": "probot run ./index.js",
-    "lint": "standard --fix",
-    "test": "jest && standard",
-    "test:watch": "jest --watch --notify --notifyMode=change --coverage"
+    "test": "jest"
   },
   "dependencies": {
     "probot": "^9.13.0"
@@ -26,24 +23,10 @@
   "devDependencies": {
     "jest": "^26.4.0",
     "nock": "^13.0.4",
-    "nodemon": "^2.0.4",
-    "smee-client": "^1.1.0",
-    "standard": "^14.3.4"
+    "smee-client": "^1.1.0"
   },
   "engines": {
     "node": ">= 10.13.0"
-  },
-  "standard": {
-    "env": [
-      "jest"
-    ]
-  },
-  "nodemonConfig": {
-    "exec": "npm start",
-    "watch": [
-      ".env",
-      "."
-    ]
   },
   "jest": {
     "testEnvironment": "node"

--- a/templates/git-data-js/CONTRIBUTING.md
+++ b/templates/git-data-js/CONTRIBUTING.md
@@ -2,7 +2,6 @@
 
 [fork]: /fork
 [pr]: /compare
-[style]: https://standardjs.com/
 [code-of-conduct]: CODE_OF_CONDUCT.md
 
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
@@ -27,7 +26,6 @@ We'd also love PRs. If you're thinking of a large PR, we advise opening up an is
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:
 
-- Follow the [style guide][style] which is using standard. Any linting errors should be shown when running `npm test`.
 - Write and update tests.
 - Keep your changes as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
 - Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).

--- a/templates/git-data-js/package.json
+++ b/templates/git-data-js/package.json
@@ -14,11 +14,8 @@
     "probot-app"
   ],
   "scripts": {
-    "dev": "nodemon",
     "start": "probot run ./index.js",
-    "lint": "standard --fix",
-    "test": "jest && standard",
-    "test:watch": "jest --watch --notify --notifyMode=change --coverage"
+    "test": "jest"
   },
   "dependencies": {
     "probot": "^9.13.0"
@@ -26,24 +23,10 @@
   "devDependencies": {
     "jest": "^26.4.0",
     "nock": "^13.0.4",
-    "nodemon": "^2.0.4",
-    "smee-client": "^1.1.0",
-    "standard": "^14.3.4"
+    "smee-client": "^1.1.0"
   },
   "engines": {
     "node": ">= 10.13.0"
-  },
-  "standard": {
-    "env": [
-      "jest"
-    ]
-  },
-  "nodemonConfig": {
-    "exec": "npm start",
-    "watch": [
-      ".env",
-      "."
-    ]
   },
   "jest": {
     "testEnvironment": "node"


### PR DESCRIPTION
fixes #158

This reduced the time to run `npm test` by 1 minute. The biggest saving would be to remove `jest`, we might want to replace that with something like `ava` for example, but that is for another day

-----
[View rendered templates/basic-js/CONTRIBUTING.md](https://github.com/probot/create-probot-app/blob/158/remove-nodemon-and-standard/templates/basic-js/CONTRIBUTING.md)
[View rendered templates/basic-ts/CONTRIBUTING.md](https://github.com/probot/create-probot-app/blob/158/remove-nodemon-and-standard/templates/basic-ts/CONTRIBUTING.md)
[View rendered templates/basic-ts/README.md](https://github.com/probot/create-probot-app/blob/158/remove-nodemon-and-standard/templates/basic-ts/README.md)
[View rendered templates/checks-js/CONTRIBUTING.md](https://github.com/probot/create-probot-app/blob/158/remove-nodemon-and-standard/templates/checks-js/CONTRIBUTING.md)
[View rendered templates/deploy-js/CONTRIBUTING.md](https://github.com/probot/create-probot-app/blob/158/remove-nodemon-and-standard/templates/deploy-js/CONTRIBUTING.md)
[View rendered templates/git-data-js/CONTRIBUTING.md](https://github.com/probot/create-probot-app/blob/158/remove-nodemon-and-standard/templates/git-data-js/CONTRIBUTING.md)