### PR TITLE
fix: use non-deprecated Probot constructor parameter

### DIFF
--- a/templates/basic-js/test/index.test.js
+++ b/templates/basic-js/test/index.test.js
@@ -22,7 +22,7 @@ describe('My Probot app', () => {
 
   beforeEach(() => {
     nock.disableNetConnect()
-    probot = new Probot({ id: 123, cert: mockCert })
+    probot = new Probot({ id: 123, privateKey: mockCert })
     // Load our app into probot
     probot.load(myProbotApp)
   })


### PR DESCRIPTION
Running `npm run test` with Probot v10.1.0 returns this warning:

```text
WARN  (Deprecation): [probot] "cert" option is deprecated. Use "privateKey" instead
```