### PR TITLE
fix: upgrade template apps to v11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ coverage
 # Miscellaneous
 .DS_Store
 Thumbs.db
+.vscode

--- a/README.md
+++ b/README.md
@@ -2,19 +2,28 @@
 
 [![CI](https://github.com/probot/create-probot-app/workflows/Test/badge.svg)](https://github.com/probot/create-probot-app/actions)
 
-This project will generate a new [Probot](https://github.com/probot/probot) app
-with everything you need to get started building. 👷🏽‍
+`create-probot-app` is a _command line_ (CLI) Node.js application that generates a new [Probot](https://github.com/probot/probot) app with everything you need to get started building. 👷🏽‍
 
-In particular, this command line interface allows you to select from our pre-defined blue prints to choose a basic working example to start from.
+More specifically, this command line interface allows you to select from our pre-defined blue prints to choose a basic working example to start from.
 
-```sh
-npx create-probot-app my-first-app
-```
+## Installation
 
-If you're using Yarn:
+Make sure you've got [Node.js installed](https://Node.js.org/en/download/) on your workstation, than open your terminal and type the following command:
 
-```sh
-yarn create probot-app my-first-app
-```
+- if you're using `npm` (the package manager bundled with `Node.js`):
+
+    ```sh
+    npx create-probot-app my-first-app
+    ```
+
+- if you're using Yarn:
+
+    ```sh
+    yarn create probot-app my-first-app
+    ```
+
+and follow the instructions printed on the terminal as you go. `create-probot-app` will then take care of the heavy lifting required to setup a Probot app development environment, with proper folder structure, and even installing all the basic `Probot` dependencies.
+
+## How to run locally
 
 See the [Probot docs](https://probot.github.io/docs/development/#running-the-app-locally) to get started running your app locally.

--- a/templates/basic-js/index.js
+++ b/templates/basic-js/index.js
@@ -1,8 +1,8 @@
 /**
  * This is the main entrypoint to your Probot app
- * @param { {app: import('probot').Application} } app
+ * @param {import('probot').Probot} app
  */
-module.exports = ({ app }) => {
+module.exports = (app) => {
   // Your code here
   app.log.info("Yay, the app was loaded!");
 

--- a/templates/basic-js/package.json
+++ b/templates/basic-js/package.json
@@ -18,12 +18,12 @@
     "test": "jest"
   },
   "dependencies": {
-    "probot": "^10.9.3"
+    "probot": "^11.0.1"
   },
   "devDependencies": {
-    "jest": "^26.4.0",
-    "nock": "^13.0.4",
-    "smee-client": "^1.1.0"
+    "jest": "^26.6.3",
+    "nock": "^13.0.5",
+    "smee-client": "^1.2.2"
   },
   "engines": {
     "node": ">= 10.13.0"

--- a/templates/basic-js/test/index.test.js
+++ b/templates/basic-js/test/index.test.js
@@ -19,7 +19,7 @@ describe("My Probot app", () => {
   beforeEach(() => {
     nock.disableNetConnect();
     probot = new Probot({
-      id: 123,
+      appId: 123,
       privateKey,
       // disable request throttling and retries for testing
       Octokit: ProbotOctokit.defaults({

--- a/templates/basic-ts/package.json
+++ b/templates/basic-ts/package.json
@@ -19,16 +19,16 @@
     "test": "jest"
   },
   "dependencies": {
-    "probot": "^10.9.5"
+    "probot": "^11.0.1"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.9",
-    "@types/node": "^14.0.27",
-    "jest": "^26.4.0",
-    "nock": "^13.0.4",
-    "smee-client": "^1.1.0",
-    "ts-jest": "^26.2.0",
-    "typescript": "^3.9.7"
+    "@types/jest": "^26.0.19",
+    "@types/node": "^14.14.19",
+    "jest": "^26.6.3",
+    "nock": "^13.0.5",
+    "smee-client": "^1.2.2",
+    "ts-jest": "^26.4.4",
+    "typescript": "^4.1.3"
   },
   "engines": {
     "node": ">= 10.13.0"

--- a/templates/basic-ts/src/index.ts
+++ b/templates/basic-ts/src/index.ts
@@ -1,6 +1,6 @@
 import { Probot } from "probot";
 
-export = ({ app }: { app: Probot }) => {
+export = (app: Probot) => {
   app.on("issues.opened", async (context) => {
     const issueComment = context.issue({
       body: "Thanks for opening this issue!",

--- a/templates/basic-ts/test/index.test.ts
+++ b/templates/basic-ts/test/index.test.ts
@@ -22,7 +22,7 @@ describe("My Probot app", () => {
   beforeEach(() => {
     nock.disableNetConnect();
     probot = new Probot({
-      id: 123,
+      appId: 123,
       privateKey,
       // disable request throttling and retries for testing
       Octokit: ProbotOctokit.defaults({

--- a/templates/checks-js/index.js
+++ b/templates/checks-js/index.js
@@ -3,9 +3,9 @@
 
 /**
  * This is the main entrypoint to your Probot app
- * @param { {app: import('probot').Application} } app
+ * @param {import('probot').Probot} app
  */
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.on(["check_suite.requested", "check_run.rerequested"], check);
 
   async function check(context) {

--- a/templates/checks-js/package.json
+++ b/templates/checks-js/package.json
@@ -18,12 +18,12 @@
     "test": "jest"
   },
   "dependencies": {
-    "probot": "^10.9.3"
+    "probot": "^11.0.1"
   },
   "devDependencies": {
-    "jest": "^26.4.0",
-    "nock": "^13.0.4",
-    "smee-client": "^1.1.0"
+    "jest": "^26.6.3",
+    "nock": "^13.0.5",
+    "smee-client": "^1.2.2"
   },
   "engines": {
     "node": ">= 10.13.0"

--- a/templates/checks-js/test/index.test.js
+++ b/templates/checks-js/test/index.test.js
@@ -20,7 +20,7 @@ describe("My Probot app", () => {
   beforeEach(() => {
     nock.disableNetConnect();
     probot = new Probot({
-      id: 123,
+      appId: 123,
       privateKey,
       // disable request throttling and retries for testing
       Octokit: ProbotOctokit.defaults({

--- a/templates/deploy-js/index.js
+++ b/templates/deploy-js/index.js
@@ -3,9 +3,9 @@
 
 /**
  * This is the main entrypoint to your Probot app
- * @param { {app: import('probot').Application} } app
+ * @param {import('probot').Probot} app
  */
-module.exports = ({ app }) => {
+module.exports = (app) => {
   // Your code here
   app.log.info("Yay, the app was loaded!");
   app.on(

--- a/templates/deploy-js/package.json
+++ b/templates/deploy-js/package.json
@@ -18,12 +18,12 @@
     "test": "jest"
   },
   "dependencies": {
-    "probot": "^10.9.3"
+    "probot": "^11.0.1"
   },
   "devDependencies": {
-    "jest": "^26.4.0",
-    "nock": "^13.0.4",
-    "smee-client": "^1.1.0"
+    "jest": "^26.6.3",
+    "nock": "^13.0.5",
+    "smee-client": "^1.2.2"
   },
   "engines": {
     "node": ">= 10.13.0"

--- a/templates/deploy-js/test/index.test.js
+++ b/templates/deploy-js/test/index.test.js
@@ -40,7 +40,7 @@ describe("My Probot app", () => {
   beforeEach(() => {
     nock.disableNetConnect();
     probot = new Probot({
-      id: 123,
+      appId: 123,
       privateKey,
       // disable request throttling and retries for testing
       Octokit: ProbotOctokit.defaults({

--- a/templates/git-data-js/index.js
+++ b/templates/git-data-js/index.js
@@ -3,9 +3,9 @@
 
 /**
  * This is the main entrypoint to your Probot app
- * @param { {app: import('probot').Application} } app
+ * @param {import('probot').Probot} app
  */
-module.exports = ({ app }) => {
+module.exports = (app) => {
   // Opens a PR every time someone installs your app for the first time
   app.on("installation.created", async (context) => {
     // shows all repos you've installed the app on

--- a/templates/git-data-js/package.json
+++ b/templates/git-data-js/package.json
@@ -18,12 +18,12 @@
     "test": "jest"
   },
   "dependencies": {
-    "probot": "^10.9.3"
+    "probot": "^11.0.1"
   },
   "devDependencies": {
-    "jest": "^26.4.0",
-    "nock": "^13.0.4",
-    "smee-client": "^1.1.0"
+    "jest": "^26.6.3",
+    "nock": "^13.0.5",
+    "smee-client": "^1.2.2"
   },
   "engines": {
     "node": ">= 10.13.0"

--- a/templates/git-data-js/test/index.test.js
+++ b/templates/git-data-js/test/index.test.js
@@ -23,7 +23,7 @@ describe("My Probot app", () => {
   beforeEach(() => {
     nock.disableNetConnect();
     probot = new Probot({
-      id: 123,
+      appId: 123,
       privateKey,
       // disable request throttling and retries for testing
       Octokit: ProbotOctokit.defaults({


### PR DESCRIPTION
- For each template:
  - fix deprecation warnings upgrading `package.json` + fixing units for latest Probot version usage
  - fix app signatures, ref: https://github.com/probot/probot/issues/1286#issuecomment-744094299
- tentative small changes to `README.md` meant to reduce frictions for new users

Note to myself: final welcome message for TypeScript users should remind about the required `build` step, I'll open a dedicated issue for it

-----
[View rendered README.md](https://github.com/shaftoe/create-probot-app/blob/upgrade-to-v11/README.md)