### PR TITLE
BREAKING CHANGE: remove support for initializing on non-empty directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tmp-test
 .DS_Store
 Thumbs.db
 .vscode
+__create_probot_app__*

--- a/script/test-template.sh
+++ b/script/test-template.sh
@@ -41,16 +41,8 @@ function check_errors_in_log() {
     echo "ok"; echo
 }
 
-# Check for .gitignore file. See https://github.com/probot/create-probot-app/issues/69
-function check_gitignore() {
-    echo -n "--[test ${TEMPLATE}]-- Ensure .gitignore exists..."
-    if [ ! -f "${TEST_FOLDER}/.gitignore" ]; then echo "No .gitignore file found."; exit 1; fi
-    echo " ok"; echo
-}
-
 echo "--[test ${TEMPLATE}]-- Run tests in ${TEST_FOLDER} folder"
 create_app
 run_npm_tests
 check_errors_in_log
-check_gitignore
 echo "--[test ${TEMPLATE}]-- All tests completed successfully!"

--- a/src/create-probot-app.ts
+++ b/src/create-probot-app.ts
@@ -6,14 +6,15 @@ import { makeScaffolding } from "./helpers/filesystem";
 import { printSuccess, red } from "./helpers/write-help";
 
 async function main(): Promise<void> {
-  const config = await askUser(runCliManager());
-
-  makeScaffolding(config)
-    .then(async () => {
+  runCliManager()
+    .then((cliConfig) => askUser(cliConfig))
+    .then((config) => makeScaffolding(config))
+    .then(async (config) => {
       if (config.gitInit) await initGit(config.destination);
+      return config;
     })
-    .then(() => installAndBuild(config.destination, config.toBuild))
-    .then(() => printSuccess(config.appName, config.destination))
+    .then(async (config) => await installAndBuild(config))
+    .then((config) => printSuccess(config.appName, config.destination))
     .catch((err) => {
       console.log(red(err));
       process.exit(1);

--- a/src/helpers/run-npm.ts
+++ b/src/helpers/run-npm.ts
@@ -1,17 +1,16 @@
 import npm from "npm";
 import { bold, yellow } from "./write-help";
+import { Config } from "./user-interaction";
 
 /**
  * Run `npm install` in `destination` folder, then run `npm run build`
  * if `toBuild` is true
  *
- * @param {String} destination Destination folder relative to current working dir
- * @param {Boolean}    toBuild Execute `npm run build` if true
+ * @param {Config} config configuration object
+ *
+ * @returns Promise which returns the input Config object
  */
-export function installAndBuild(
-  destination: string,
-  toBuild: boolean
-): Promise<void> {
+export function installAndBuild(config: Config): Promise<Config> {
   class NpmError extends Error {
     constructor(msg: string, command: string) {
       const message = `
@@ -26,11 +25,11 @@ Try running ${bold("npm " + command)} yourself.
 
   return new Promise((resolve, reject) => {
     const previousDir: string = process.cwd();
-    process.chdir(destination);
+    process.chdir(config.destination);
 
     const chdirAndResolve = (): void => {
       process.chdir(previousDir);
-      resolve();
+      resolve(config);
     };
 
     npm.load(function (err) {
@@ -42,7 +41,7 @@ Try running ${bold("npm " + command)} yourself.
 
       npm.commands.install([], function (err) {
         if (err) reject(new NpmError("install npm dependencies", "install"));
-        else if (toBuild) {
+        else if (config.toBuild) {
           console.log(yellow("\n\nCompile application...\n"));
           npm.commands["run-script"](["build"], function (err) {
             if (err) reject(new NpmError("build application", "run build"));

--- a/src/helpers/user-interaction.ts
+++ b/src/helpers/user-interaction.ts
@@ -10,7 +10,7 @@ import stringifyAuthor from "stringify-author";
 import validatePackageName from "validate-npm-package-name";
 
 import { blue, red, printHelpAndFail } from "./write-help";
-import { getTemplates } from "./filesystem";
+import { getTemplates, ensureValidDestination } from "./filesystem";
 
 type QuestionI =
   | (
@@ -183,9 +183,9 @@ export async function askUser(config: CliConfig): Promise<Config> {
 /**
  * Run CLI manager to parse user provided options and arguments
  *
- * @returns the configuration options set via CLI
+ * @returns resolves with the configuration options set via CLI
  */
-export function runCliManager(): CliConfig {
+export async function runCliManager(): Promise<CliConfig> {
   let destination: string = "";
 
   // TSC mangles output directory when using normal import methods for
@@ -218,6 +218,8 @@ export function runCliManager(): CliConfig {
   const options = program.parse(process.argv).opts();
 
   if (!destination) printHelpAndFail();
+  ensureValidDestination(destination, options.overwrite);
+
   if (options.showTemplates) {
     getTemplates().forEach((template) => console.log(template));
     process.exit();


### PR DESCRIPTION
I think the current logic dealing with `.gitignore` is broken, plus, I couldn't understand why we need to update its content if a file with same name is already available in the target folder.

In my opinion we should treat `.gitignore` as every other templated file in order to be idempotent, i.e. if the target file exists than skip creation all together.