### PR TITLE
fix: add `homepage` to each template's package.json file

### DIFF
--- a/templates/basic-js/package.json
+++ b/templates/basic-js/package.json
@@ -5,6 +5,7 @@
   "description": "{{{ description }}}",
   "author": "{{{ author }}}",
   "license": "ISC",
+  "homepage": "https://github.com/{{ owner }}/{{ repo }}",
   "keywords": [
     "probot",
     "github",

--- a/templates/basic-ts/package.json
+++ b/templates/basic-ts/package.json
@@ -5,6 +5,7 @@
   "description": "{{{ description }}}",
   "author": "{{{ author }}}",
   "license": "ISC",
+  "homepage": "https://github.com/{{ owner }}/{{ repo }}",
   "keywords": [
     "probot",
     "github",

--- a/templates/checks-js/package.json
+++ b/templates/checks-js/package.json
@@ -5,6 +5,7 @@
   "description": "{{{ description }}}",
   "author": "{{{ author }}}",
   "license": "ISC",
+  "homepage": "https://github.com/{{ owner }}/{{ repo }}",
   "keywords": [
     "probot",
     "github",

--- a/templates/deploy-js/package.json
+++ b/templates/deploy-js/package.json
@@ -5,6 +5,7 @@
   "description": "{{{ description }}}",
   "author": "{{{ author }}}",
   "license": "ISC",
+  "homepage": "https://github.com/{{ owner }}/{{ repo }}",
   "keywords": [
     "probot",
     "github",

--- a/templates/git-data-js/package.json
+++ b/templates/git-data-js/package.json
@@ -5,6 +5,7 @@
   "description": "{{{ description }}}",
   "author": "{{{ author }}}",
   "license": "ISC",
+  "homepage": "https://github.com/{{ owner }}/{{ repo }}",
   "keywords": [
     "probot",
     "github",


### PR DESCRIPTION
probot/probot reads the `homepage` key from `package.json` during Probot App Setup to set the GitHub App Manifest's `url`, a required property to programmatically create GitHub Apps.

fixes: #346
