### PR TITLE
Add option to watch and serve changes

### DIFF
--- a/templates/basic-ts/package.json
+++ b/templates/basic-ts/package.json
@@ -14,7 +14,10 @@
   "scripts": {
     "build": "tsc",
     "start": "probot run ./lib/index.js",
-    "test": "jest"
+    "test": "jest",
+    "watch": "concurrently -k -p \"[{name}]\" -n \"TypeScript,Node\" -c \"cyan.bold,green.bold\" \"npm run watch-ts\" \"npm run watch-node\"",
+    "watch-node": "probot run ./lib/index.js",
+    "watch-ts": "tsc -w"
   },
   "dependencies": {
     "probot": "^11.0.1"
@@ -22,6 +25,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.19",
     "@types/node": "^14.14.19",
+    "concurrently": "^5.3.0",
     "jest": "^26.6.3",
     "nock": "^13.0.5",
     "smee-client": "^1.2.2",


### PR DESCRIPTION
Hi 👋 Thought it might be helpful for devs to support using `tsc -w` to watch for typescript changes and serve them up immediately instead of requiring `npm run build && npm start`.