### PR TITLE
fix: jest testEnvironment for basic-js and basic-ts templates

### DIFF
--- a/templates/basic-js/package.json
+++ b/templates/basic-js/package.json
@@ -25,5 +25,8 @@
   },
   "engines": {
     "node": ">= 10.13.0"
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }

--- a/templates/basic-ts/jest.config.js
+++ b/templates/basic-ts/jest.config.js
@@ -5,4 +5,5 @@ module.exports = {
   },
   testRegex: "(/__tests__/.*|\\.(test|spec))\\.[tj]sx?$",
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+  testEnvironment: "node",
 };

--- a/templates/basic-ts/package.json
+++ b/templates/basic-ts/package.json
@@ -30,8 +30,5 @@
   },
   "engines": {
     "node": ">= 10.13.0"
-  },
-  "jest": {
-    "testEnvironment": "node"
   }
 }


### PR DESCRIPTION
`testEnvironment` isn't configured in the basic-js template, so it defaults to `jsdom`. This configures it to `node`.

`testEnvironment` was configured in the `basic-ts` template, but Jest will only read configuration from one of its supported locations and in this case that's `jest.config.js`.

Running `npm test -- --debug` in a basic-ts app before:

![Screen Shot 2021-03-20 at 3 59 28 PM](https://user-images.githubusercontent.com/14145352/111885863-4f18ed00-8998-11eb-873d-edef23c80687.png)

Running `npm test -- --debug` in a basic-ts app after:

![Screen Shot 2021-03-20 at 4 00 41 PM](https://user-images.githubusercontent.com/14145352/111885876-5e983600-8998-11eb-9f32-f16fd87f98e8.png)