### PR TITLE
🎉 Feature: support dockerized execution with single command 🐳 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,5 @@
 *.md
 dist
 node_modules/
+Dockerfile
+docker-compose.yaml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.gitignore
+.git
+.github
+*.md
+dist
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ COPY . .
 
 RUN pnpm run build
 
-CMD [ "node", "bin/" ]
+ENTRYPOINT [ "node", "./bin/create-probot-app.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM node:20-slim AS base
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+COPY . /app
+WORKDIR /app
+
+FROM base AS prod-deps
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --frozen-lockfile
+
+FROM base AS build
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+RUN pnpm run build
+
+FROM base
+COPY --from=prod-deps /app/node_modules /app/node_modules
+COPY --from=build /app/dist /app/dist
+EXPOSE 8000
+
+FROM base AS app-dependencies
+
+WORKDIR /github.com/marcellodesales/probot
+
+COPY package* .
+
+RUN pnpm install 
+
+FROM app-dependencies
+
+COPY . . 
+
+RUN pnpm run build
+
+CMD [ "node", "bin/" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,7 @@
+services:
+
+  create-probot-app:
+    image: marcellodesales/create-probot-app
+    build:
+      context: .
+     

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "jsesc": "^3.0.1",
     "lodash.camelcase": "^4.3.0",
     "lodash.kebabcase": "^4.1.1",
-    "npm": "^9.0.0",
+    "npm": "^7.0.0",
     "simple-git": "^3.0.3",
     "stringify-author": "^0.1.3",
     "validate-npm-package-name": "^5.0.0"


### PR DESCRIPTION
# 🎉 Support for Dockerized execution

* Create bot source-code using docker containers doesn't require installation of nodejs etc..
* Requires `docker engine`

1. Create an empty dir and cd to it
2. Execute docker command
3. Profit! The code is generated!

> **DOCKER COMMAND**: docker run -ti -w $(pwd) -v $(pwd):$(pwd) marcellodesales/create-probot-app vionix-ghas-manager`

<details><summary>docker run -ti -w $(pwd) -v $(pwd):$(pwd) marcellodesales/create-probot-app vionix-ghas-manager</summary>

```console
Let's create a Probot app!
Hit enter to accept the suggestion.

? App name: vionix-ghas-manager
? Description of app: Manages Github Advanced Security features for a Github organization.
? Author's full name: Marcello DeSales
? Which template would you like to use? git-data-js => Opens a PR every time someone installs your app for the first time
created file: /Users/mdesales/dev/git.viasat.com/seceng-devsecops-platform/devsecops-github-app-ghas-onboard/vionix-ghas-manager/.dockerignore
created file: /Users/mdesales/dev/git.viasat.com/seceng-devsecops-platform/devsecops-github-app-ghas-onboard/vionix-ghas-manager/.env.example
created file: /Users/mdesales/dev/git.viasat.com/seceng-devsecops-platform/devsecops-github-app-ghas-onboard/vionix-ghas-manager/CODE_OF_CONDUCT.md
created file: /Users/mdesales/dev/git.viasat.com/seceng-devsecops-platform/devsecops-github-app-ghas-onboard/vionix-ghas-manager/CONTRIBUTING.md
created file: /Users/mdesales/dev/git.viasat.com/seceng-devsecops-platform/devsecops-github-app-ghas-onboard/vionix-ghas-manager/Dockerfile
created file: /Users/mdesales/dev/git.viasat.com/seceng-devsecops-platform/devsecops-github-app-ghas-onboard/vionix-ghas-manager/LICENSE
created file: /Users/mdesales/dev/git.viasat.com/seceng-devsecops-platform/devsecops-github-app-ghas-onboard/vionix-ghas-manager/README.md
created file: /Users/mdesales/dev/git.viasat.com/seceng-devsecops-platform/devsecops-github-app-ghas-onboard/vionix-ghas-manager/app.yml
created file: /Users/mdesales/dev/git.viasat.com/seceng-devsecops-platform/devsecops-github-app-ghas-onboard/vionix-ghas-manager/index.js
created file: /Users/mdesales/dev/git.viasat.com/seceng-devsecops-platform/devsecops-github-app-ghas-onboard/vionix-ghas-manager/package.json
created file: /Users/mdesales/dev/git.viasat.com/seceng-devsecops-platform/devsecops-github-app-ghas-onboard/vionix-ghas-manager/.gitignore
created file: /Users/mdesales/dev/git.viasat.com/seceng-devsecops-platform/devsecops-github-app-ghas-onboard/vionix-ghas-manager/test/index.test.js
created file: /Users/mdesales/dev/git.viasat.com/seceng-devsecops-platform/devsecops-github-app-ghas-onboard/vionix-ghas-manager/test/fixtures/installation.created.json
created file: /Users/mdesales/dev/git.viasat.com/seceng-devsecops-platform/devsecops-github-app-ghas-onboard/vionix-ghas-manager/test/fixtures/mock-cert.pem

Finished scaffolding files!

Installing dependencies. This may take a few minutes...

npm WARN deprecated @types/pino-pretty@5.0.0: This is a stub types definition. pino-pretty provides its own type definitions, so you do not need this installed.
npm WARN deprecated @types/pino-std-serializers@4.0.0: This is a stub types definition. pino-std-serializers provides its own type definitions, so you do not need this installed.

added 604 packages, and audited 605 packages in 3m

43 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

Successfully created vionix-ghas-manager.

Begin using your app with:

  cd vionix-ghas-manager
  npm start

Refer to your app's README for more usage instructions.

Visit the Probot docs
  https://probot.github.io/docs/

Get help from the community:
  https://probot.github.io/community/

Enjoy building your Probot app!
```
</details>

