### PR TITLE
ci: remove NodeJS 14+16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
     strategy:
       matrix:
         node:
-          - 14
-          - 16
           - 18
+          - 20
+          - 21
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Follow up to #814 which made the required Node version `>= 16.7.0`