### PR TITLE
ci(release): add permissions for OIDC and npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
   push:
     branches:
       - master
+permissions:
+  id-token: write # to enable use of OIDC for trusted publishing and npm provenance
+  contents: write # tags and releases
+  pull-requests: write # comments
+  issues: write # comments
+
 jobs:
   release:
     name: release
@@ -18,4 +24,3 @@ jobs:
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.PROBOTBOT_NPM_TOKEN }}


### PR DESCRIPTION
Enables npm provenance via OIDC trusted publishing. Removes `NPM_TOKEN` dependency.

See https://github.com/gr2m/semantic-release-plugin-update-version-in-files/pull/62 for reference.